### PR TITLE
Add support for tcp-check and http-check configuration

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -252,6 +252,42 @@ registries)
                 port: 8082
                 params: backup check
 
+Custom listener with tcp-check options specified (for Redis cluster with Sentinel)
+
+.. code-block:: yaml
+
+  haproxy:
+    proxy:
+      listen:
+        redis_cluster:
+          service_name: redis
+          check:
+            tcp:
+              enabled: True
+              options:
+                - send PING\r\n
+                - expect string +PONG
+                - send info\ replication\r\n
+                - expect string role:master
+                - send QUIT\r\n
+                - expect string +OK
+          binds:
+            - address: ${_param:cluster_address}
+              port: 6379
+          servers:
+            - name: ${_param:cluster_node01_name}
+              host: ${_param:cluster_node01_address}
+              port: 6379
+              params: check inter 1s
+            - name: ${_param:cluster_node02_name}
+              host: ${_param:cluster_node02_address}
+              port: 6379
+              params: check inter 1s
+            - name: ${_param:cluster_node03_name}
+              host: ${_param:cluster_node03_address}
+              port: 6379
+              params: check inter 1s
+
 Read more
 =========
 

--- a/haproxy/files/haproxy.cfg
+++ b/haproxy/files/haproxy.cfg
@@ -167,6 +167,16 @@ listen {{ listen_name }}
   {%- for option in listen.get('options', []) %}
   option {{ option }}
   {%- endfor %}
+  {%- for type, checks in listen.get('check', {}).iteritems() %}
+  {%- if checks.get('enabled', True) %}
+  {%- if type + '-check' not in listen.get('options', []) %}
+  option {{ type }}-check
+  {%- endif %}
+  {%- for option in checks.get('options', []) %}
+  {{ type }}-check {{ option }}
+  {%- endfor %}
+  {%- endif %}
+  {%- endfor %}
   {%- for stick in listen.get('sticks', []) %}
   {{ stick }}
   {%- endfor %}


### PR DESCRIPTION
Add support for tcp-check and http-check configuration, sample metadata:

```
  ...
  haproxy:
    proxy:
      listen:
        redis_cluster:
          service_name: redis
          check:
            tcp:
              enabled: True
              options:
                - send PING\r\n
                - expect string +PONG
                - send info\ replication\r\n
                - expect string role:master
                - send QUIT\r\n
                - expect string +OK
          ...
```

Resulting HAproxy configuration:

```
listen redis_cluster
  ...
  option tcp-check
  tcp-check send PING\r\n
  tcp-check expect string +PONG
  tcp-check send info\ replication\r\n
  tcp-check expect string role:master
  tcp-check send QUIT\r\n
  tcp-check expect string +OK
  ...
