### PR TITLE
Multicore config

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -391,6 +391,42 @@ Enable customisable ``forwardfor`` option in ``defaults`` section.
         header: X-Real-IP
         if-none: false
 
+Sample pillar with multiprocess multicore configuration
+
+.. code-block:: yaml
+
+  haproxy:
+    proxy:
+      enabled: True
+      nbproc: 4
+      cpu_map:
+        1: 0
+        2: 1
+        3: 2
+        4: 3
+      stats_bind_process: "1 2"
+      mode: http/tcp
+      logging: syslog
+      maxconn: 1024
+      timeout:
+        connect: 5000
+        client: 50000
+        server: 50000
+      listen:
+        https-in:
+          bind_process: "1 2 3 4"
+          binds:
+          - address: 0.0.0.0
+            port: 443
+          servers:
+          - name: server1
+            host: 10.0.0.1
+            port: 8443
+          - name: server2
+            host: 10.0.0.2
+            port: 8443
+            params: 'maxconn 256'
+
 Read more
 =========
 

--- a/haproxy/files/haproxy.cfg
+++ b/haproxy/files/haproxy.cfg
@@ -1,11 +1,20 @@
 {%- from "haproxy/map.jinja" import proxy with context -%}
 
 global
+{%- if proxy.nbproc is defined %}
+  nbproc {{ proxy.nbproc }}
+{%- endif %}
+{%- for process, cpu in proxy.get('cpu_map', {}).iteritems() %}
+  cpu-map {{ process }} {{ cpu }}
+{%- endfor %}
   log /dev/log  local0
   log /dev/log  local1 notice
   chroot /var/lib/haproxy
   stats  socket {{ proxy.stats_socket }} mode 660 level admin
   stats timeout 30s
+{%- if proxy.stats_bind_process is defined %}
+  stats bind-process {{ proxy.stats_bind_process }}
+{%- endif %}
   user  haproxy
   group haproxy
   daemon
@@ -68,6 +77,9 @@ listen {{ listen_name }}
   {%- for bind in listen.binds %}
   bind {{ bind.address }}:{{ bind.port }} {% if bind.get('ssl', {}).enabled|default(False) %}{% if bind.ssl.pem_file is defined %}ssl crt {{ bind.ssl.pem_file }}{% else %}ssl crt /etc/haproxy/ssl/{{ listen_name }}{% endif %}{% endif %}
   {%- endfor %}
+  {%- if listen.bind_process is defined %}
+  bind-process {{ listen.bind_process }}
+  {%- endif %}
   {%- if listen.get('type', None) == 'http' %}
   mode http
   balance {{ listen.get('balance', 'roundrobin') }}

--- a/tests/pillar/single_general_service.sls
+++ b/tests/pillar/single_general_service.sls
@@ -4,9 +4,17 @@ haproxy:
     mode: tcp
     logging: syslog
     max_connections: 1024
+    nbproc: 4
+    cpu_map:
+      1: 0
+      2: 1
+      3: 2
+      4: 3
+    stats_bind_process: "1 2"
     listen:
       glance_api:
         type: openstack-service
+        bind_process: "1 2 3 4"
         binds:
         - address: 127.0.0.1
           port: 9292


### PR DESCRIPTION
Introducing optional parameters for multicore multiprocess support:

nbproc - number of processes
cpu-map - pin process to core
bind-process - limit visibility of an instance to a certain set of processes numbers

Thanks.