### PR TITLE
Make stick-table size configurable for rate-limiting

### DIFF
--- a/haproxy/files/haproxy.cfg
+++ b/haproxy/files/haproxy.cfg
@@ -256,7 +256,7 @@ frontend  {{ listen_name }}
   tcp-request inspect-delay 5s
   acl too_many_requests sc0_gpc0_rate() gt {{ listen.rate_limit.get('requests', 100) }}
   acl mark_seen sc0_inc_gpc0 gt 0
-  stick-table type string size 100k store gpc0_rate({{ listen.rate_limit.get('duration', '60s') }})
+  stick-table type string size {{ listen.rate_limit.get('size', '100k') }} store gpc0_rate({{ listen.rate_limit.get('duration', '60s') }})
   {%- if listen.rate_limit.get('track', 'content') == 'content' %}
   tcp-request content track-sc0 {{ listen.rate_limit.get('header', 'hdr(X-Forwarded-For)') }} if ! too_many_requests
   {%- else %}


### PR DESCRIPTION
A 100k size is enough to store approx 1500 ip adresses (which in our case was not enough..)
Or approximate 1000 instance uuids (if tracking the X-Instance-ID header)

Based on haproxy manual:
"Count approximately 50 bytes per entry, plus the size of a string if any."

So say an IP is 15 chars, then a entry is 65 bytes; in a 100k size this is 1575 entries.
If tracking instance uuids, then a entry is 50 + 36 (=86) chars, which would yield 1190 entries if using 100k size