### PR TITLE
set x-forwarded-proto when listening in ssl

### DIFF
--- a/haproxy/files/haproxy.cfg
+++ b/haproxy/files/haproxy.cfg
@@ -232,6 +232,9 @@ listen {{ listen_name }}
 frontend  {{ listen_name }}
   {%- for bind in listen.binds %}
   bind {{ bind.address }}:{{ bind.port }} {% if bind.get('ssl', {}).enabled|default(False) %} {% if bind.ssl.pem_file is defined %}ssl crt {{ bind.ssl.pem_file }}{% else %}ssl crt /etc/haproxy/ssl/{{ listen_name }}{% endif %} {% endif %}
+  {% if bind.get('ssl', {}).enabled|default(False) %}
+  http-request set-header X-Forwarded-Proto https if { ssl_fc }
+  {% endif %}
   {% endfor %}
   {% if listen.get('force_ssl') == true %}
   redirect scheme https code 301 if !{ ssl_fc }


### PR DESCRIPTION
so backend knows connection was using ssl even if backend uses plain http